### PR TITLE
Use "LearnToCode" category

### DIFF
--- a/com.endlessnetwork.whitehouse.appdata.xml
+++ b/com.endlessnetwork.whitehouse.appdata.xml
@@ -11,6 +11,10 @@
   <description>
     <p>Do not judge a book by its cover or lack of color! This time, you get to decide what color this world should be. Dive into the magical world of CSS and hack the world into a unique burst of color and light revealing hidden objects and clues. Learn basic CSS techniques used to color and set attributes to the 3D objects in this unique town. Want to paint the rest of the town? Well, get through the house first, and you might just get to leave through the front door.</p>
   </description>
+  <categories>
+    <category>LearnToCode</category>
+    <category>Game</category>
+  </categories>
   <releases>
     <release version="1.175" date="2019-09-18"/>
   </releases>

--- a/com.endlessnetwork.whitehouse.desktop
+++ b/com.endlessnetwork.whitehouse.desktop
@@ -6,5 +6,5 @@ Exec=com.endlessnetwork.whitehouse.sh
 Icon=com.endlessnetwork.whitehouse
 Terminal=false
 Type=Application
-Categories=Game;X-LearnToCode;
+Categories=Game;
 Keywords=game;programming;puzzle;casual;


### PR DESCRIPTION
This non-standard category is used to populate the "Learn to Code" tab
in the Endless OS app center.

While it's true that LearnToCode is not a standard category name, and so
(by the spec) we should be using the X- prefix for a vendor extension,
in practice X-prefixed categories do not appear in the Flathub
appstream, and the app center only looks for LearnToCode anyway.